### PR TITLE
Ignore build and vscode directory

### DIFF
--- a/espGarden/.gitignore
+++ b/espGarden/.gitignore
@@ -1,0 +1,5 @@
+# Ignore build directory
+build/
+
+# Ignore .vscode directory
+.vscode/

--- a/espGarden/customizeUser.bat
+++ b/espGarden/customizeUser.bat
@@ -27,4 +27,11 @@ if not exist "!file!" (
 move /Y "!tempfile!" "!file!" > NUL
 
 echo Replacement complete.
+
+:: Git ignore
+echo Configuring .vscode to be skipped for future changes...
+git update-index --skip-worktree -r .vscode/
+echo Done. .vscode directory changes will now be ignored.
+
+
 endlocal


### PR DESCRIPTION
Adds line for script to ignore changes to .vscode for customization. Works on old and new clones